### PR TITLE
dont create output secret if it is nil

### DIFF
--- a/pkg/keycloak/realm/phaseHandler.go
+++ b/pkg/keycloak/realm/phaseHandler.go
@@ -413,7 +413,7 @@ func (ph *phaseHandler) Deprovision(realm *v1alpha1.KeycloakRealm) (*v1alpha1.Ke
 
 	//delete client secrets
 	for _, client := range realm.Spec.Clients {
-		if client.OutputSecret == nil{
+		if client.OutputSecret == nil {
 			continue
 		}
 		clientSecret := &corev1.Secret{

--- a/pkg/keycloak/realm/phaseHandler.go
+++ b/pkg/keycloak/realm/phaseHandler.go
@@ -413,6 +413,9 @@ func (ph *phaseHandler) Deprovision(realm *v1alpha1.KeycloakRealm) (*v1alpha1.Ke
 
 	//delete client secrets
 	for _, client := range realm.Spec.Clients {
+		if client.OutputSecret == nil{
+			continue
+		}
 		clientSecret := &corev1.Secret{
 			TypeMeta: v1.TypeMeta{
 				APIVersion: "v1",

--- a/pkg/keycloak/realm/phaseHandler.go
+++ b/pkg/keycloak/realm/phaseHandler.go
@@ -300,8 +300,8 @@ func (ph *phaseHandler) reconcileClient(kcClient, specClient *v1alpha1.KeycloakC
 			}
 		}
 	}
-
-	if specClient != nil {
+	logrus.Info("reconciling client", specClient)
+	if specClient != nil && specClient.OutputSecret != nil {
 		cs, err := authenticatedClient.GetClientSecret(specClient.ID, realmName)
 		if err != nil {
 			return err

--- a/tmp/build/Dockerfile
+++ b/tmp/build/Dockerfile
@@ -5,5 +5,5 @@ USER keycloak-operator
 ENV PATH="/home/keycloak-operator:${PATH}"
 ENV TEMPLATE_DIR="/home/keycloak-operator/deploy/template"
 ADD tmp/_output/bin/keycloak-operator /home/keycloak-operator/keycloak-operator
-ADD tmp/_output/deploy/template/sso72-x509-postgresql-persistent.json /home/keycloak-operator/deploy/template/sso72-x509-postgresql-persistent.json
+ADD deploy/template/sso72-x509-postgresql-persistent.json /home/keycloak-operator/deploy/template/sso72-x509-postgresql-persistent.json
 


### PR DESCRIPTION
## Motivation
Testing apicurio install caused the keycloak operator to fail.
This was because it was attempting to get the value from a nil pointer 
If there is no outPutSecret then the operator should not crash and just not create a secret.
## Verification Steps
Create a client without an output secret. The operator should not fail

