### PR TITLE
Update travis push stage to update a branch tag

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,5 +25,9 @@ jobs:
     - make docker-build-image TAG=$(git rev-parse --short ${TRAVIS_COMMIT})
   - stage: push
     script:
+    - export BRANCH=$(if [ "$TRAVIS_PULL_REQUEST" == "false" ]; then echo $TRAVIS_BRANCH; else echo $TRAVIS_PULL_REQUEST_BRANCH; fi)
+    - export TAG=$(git rev-parse --short ${TRAVIS_COMMIT})
     - docker login --password "$QUAY_PASSWORD" --username "$QUAY_USERNAME" quay.io
-    - make docker-build-and-push TAG=$(git rev-parse --short ${TRAVIS_COMMIT})
+    - make docker-build-and-push TAG=$TAG
+    - docker tag quay.io/integreatly/$OPERATOR_NAME:$TAG quay.io/integreatly/$OPERATOR_NAME:$BRANCH
+    - docker push quay.io/integreatly/$OPERATOR_NAME:$BRANCH

--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -14,7 +14,7 @@ spec:
     spec:
       containers:
         - name: keycloak-operator
-          image: quay.io/integreatly/keycloak-operator:0.0.2
+          image: quay.io/integreatly/keycloak-operator:master
           ports:
           - containerPort: 60000
             name: metrics


### PR DESCRIPTION
## Motivation
This change allows a tag with the same name as the current branch (e.g. master) to be be created/updated when a branch is updated.

Main reason for this is so we can have a "master" tag always kept up to date when a PR is merged back.

## Verification Steps
* Ensure a tag is created/updated for this branch in quay.io https://quay.io/repository/integreatly/keycloak-operator
