### PR TITLE
add version to the status field of the keycloak custom resource

### DIFF
--- a/deploy/examples/keycloak.json
+++ b/deploy/examples/keycloak.json
@@ -5,7 +5,6 @@
     "name": "example"
   },
   "spec": {
-    "version": "4.1.0",
     "adminCredentials": ""
   }
 }

--- a/deploy/examples/keycloak_min.json
+++ b/deploy/examples/keycloak_min.json
@@ -8,7 +8,6 @@
     ]
   },
   "spec": {
-    "version": "4.1.0",
     "adminCredentials": ""
   }
 }

--- a/pkg/apis/aerogear/v1alpha1/types.go
+++ b/pkg/apis/aerogear/v1alpha1/types.go
@@ -12,7 +12,6 @@ const (
 	Version           = "v1alpha1"
 	KeycloakKind      = "Keycloak"
 	KeycloakRealmKind = "KeycloakRealm"
-	KeycloakVersion   = "4.1.0"
 	KeycloakFinalizer = "finalizer.org.aerogear.keycloak"
 )
 
@@ -47,7 +46,6 @@ func (k *Keycloak) Validate() error {
 }
 
 type KeycloakSpec struct {
-	Version          string `json:"version"`
 	AdminCredentials string `json:"adminCredentials"`
 }
 
@@ -207,7 +205,8 @@ type GenericStatus struct {
 	Message  string      `json:"message"`
 	Attempts int         `json:"attempts"`
 	// marked as true when all work is done on it
-	Ready bool `json:"ready"`
+	Ready   bool   `json:"ready"`
+	Version string `json:"version"`
 }
 
 type KeycloakStatus struct {

--- a/pkg/keycloak/keycloak.go
+++ b/pkg/keycloak/keycloak.go
@@ -27,6 +27,7 @@ const (
 	SSO_APPLICATION_NAME      = "sso"
 	SSO_TEMPLATE_PATH         = "deploy/template"
 	SSO_TEMPLATE_PATH_ENV_VAR = "TEMPLATE_DIR"
+	SSO_VERSION               = "7.2.2"
 )
 
 //go:generate moq -out sdkCruder_moq.go . SdkCruder

--- a/pkg/keycloak/phaseHandler.go
+++ b/pkg/keycloak/phaseHandler.go
@@ -49,6 +49,7 @@ func (ph *phaseHandler) Initialise(sso *v1alpha1.Keycloak) (*v1alpha1.Keycloak, 
 	}
 	// set the phase to accepted or set a message that it cannot be accepted
 	kcState.Status.Phase = v1alpha1.PhaseAccepted
+	kcState.Status.Version = SSO_VERSION
 	return kcState, nil
 }
 


### PR DESCRIPTION
## What
- Remove the `version` field from the Keycloak custom resource spec as this is not used.
- Add a `version` field in the `status` field of the Keycloak custom resource to reflect the version installed by the operator. The current [template](https://gist.github.com/philbrookes/6e6867f9e89fd598ee0b48dcb8317ae1#file-gistfile1-txt-L273) used by the operator installs version `7.2.2`. 

## Why
Ensures that the version installed by the operator can be seen within the `status.version` field. 

## Verification Steps
1. Run `make install create-examples`
2. Ensure that the `status.version` field in the `Keycloak` custom resource reflects the version installed by the operator.

## Checklist:

- [x] Code has been tested locally by PR requester
- [x] Changes have been successfully verified by another team member
