### PR TITLE
INTLY-1100 Add labels to the created CronJobs based on Keycloak CR

### DIFF
--- a/deploy/examples/keycloak_backed_up.json
+++ b/deploy/examples/keycloak_backed_up.json
@@ -10,6 +10,9 @@
     "backups": [
       {
         "name": "daily-at-midnight",
+        "labels": {
+          "monitoring-key": "middleware"
+        },
         "schedule": "0 0 * * *",
         "encryption_key_secret_name": "example-encryption-key",
         "aws_credentials_secret_name": "example-aws-key",

--- a/pkg/apis/aerogear/v1alpha1/types.go
+++ b/pkg/apis/aerogear/v1alpha1/types.go
@@ -53,13 +53,14 @@ type KeycloakSpec struct {
 
 //KeycloakBackup details of a backup task
 type KeycloakBackup struct {
-	Name                     string `json:"name"`
-	Schedule                 string `json:"schedule"`
-	EncryptionKeySecretName  string `json:"encryption_key_secret_name"`
-	AwsCredentialsSecretName string `json:"aws_credentials_secret_name"`
-	DbCredentialsSecretName  string `json:"db_credentials_secret_name"`
-	Image                    string `json:"image"`
-	ImageTag                 string `json:"image_tag"`
+	Name                     string            `json:"name"`
+	Labels                   map[string]string `json:"labels"`
+	Schedule                 string            `json:"schedule"`
+	EncryptionKeySecretName  string            `json:"encryption_key_secret_name"`
+	AwsCredentialsSecretName string            `json:"aws_credentials_secret_name"`
+	DbCredentialsSecretName  string            `json:"db_credentials_secret_name"`
+	Image                    string            `json:"image"`
+	ImageTag                 string            `json:"image_tag"`
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object


### PR DESCRIPTION
Add a `labels` map to the `backups` that can be provided in the
Keycloak custom resource. These will be appended to the default
existing labels.

Also add a default label for the Job that the CronJob creates that
links it back to the parent CronJob.

Verification:
- Run the operator
- Create `deploy/examples/keycloak_backed_up.json`
- Ensure that a CronJob is created
- Ensure that the CronJob has a label `monitoring-key: middleware`
- Ensure the Job created from that CronJob has the same label