### PR TITLE
INTLY-1201 use master image tag in master branch

### DIFF
--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -14,7 +14,7 @@ spec:
     spec:
       containers:
         - name: keycloak-operator
-          image: quay.io/integreatly/keycloak-operator:v1.2.3
+          image: quay.io/integreatly/keycloak-operator:master
           ports:
           - containerPort: 60000
             name: metrics


### PR DESCRIPTION
See https://issues.jboss.org/browse/INTLY-1201. We want to be sure we test the latest stuff and thus we think there should be a master image tag in the master branch.