### PR TITLE
add monitoring label to dashboard

### DIFF
--- a/deploy/template/grafana-dashboard.yaml
+++ b/deploy/template/grafana-dashboard.yaml
@@ -3,6 +3,8 @@ kind: GrafanaDashboard
 metadata:
   name: keycloak
   namespace: [[ .Namespace ]]
+  labels:
+    monitoring-key: middleware
 spec:
   json: >
     {


### PR DESCRIPTION
The keycloak dasboard needs to be labelled for the grafana operator to discover it