### PR TITLE
upgrade logic from 7.2 to 7.3

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -2,260 +2,203 @@
 
 
 [[projects]]
-  digest = "1:6eefbb45475750bda6fc0331c36acd2015640ec5ed2ff7f8e2b0646aee451175"
   name = "github.com/Jeffail/gabs"
   packages = ["."]
-  pruneopts = "NUT"
   revision = "7be49c3f43696c7ca8c9a76d6836703d83aea404"
   version = "v1.1.1"
 
 [[projects]]
-  digest = "1:d8ebbd207f3d3266d4423ce4860c9f3794956306ded6c7ba312ecc69cdfbf04c"
   name = "github.com/PuerkitoBio/purell"
   packages = ["."]
-  pruneopts = "NUT"
   revision = "0bcb03f4b4d0a9428594752bd2a3b9aa0a9d4bd4"
   version = "v1.1.0"
 
 [[projects]]
   branch = "master"
-  digest = "1:8098cd40cd09879efbf12e33bcd51ead4a66006ac802cd563a66c4f3373b9727"
   name = "github.com/PuerkitoBio/urlesc"
   packages = ["."]
-  pruneopts = "NUT"
   revision = "de5bf2ad457846296e2031421a34e2568e304e35"
 
 [[projects]]
   branch = "master"
-  digest = "1:707ebe952a8b3d00b343c01536c79c73771d100f63ec6babeaed5c79e2b8a8dd"
   name = "github.com/beorn7/perks"
   packages = ["quantile"]
-  pruneopts = "NUT"
   revision = "3a771d992973f24aa725d07868b467d1ddfceafb"
 
 [[projects]]
-  digest = "1:ffe9824d294da03b391f44e1ae8281281b4afc1bdaa9588c9097785e3af10cec"
   name = "github.com/davecgh/go-spew"
   packages = ["spew"]
-  pruneopts = "NUT"
   revision = "8991bc29aa16c548c550c7ff78260e27b9ab7c73"
   version = "v1.1.1"
 
 [[projects]]
-  digest = "1:3537d33c077a9666720dc987fddfecb07270606ac0a58f67abd08e3b252c0a45"
   name = "github.com/emicklei/go-restful"
   packages = [
     ".",
-    "log",
+    "log"
   ]
-  pruneopts = "NUT"
   revision = "3eb9738c1697594ea6e71a7156a9bb32ed216cf0"
   version = "v2.8.0"
 
 [[projects]]
-  digest = "1:81466b4218bf6adddac2572a30ac733a9255919bc2f470b4827a317bd4ee1756"
   name = "github.com/ghodss/yaml"
   packages = ["."]
-  pruneopts = "NUT"
   revision = "0ca9ea5df5451ffdf184b4428c902747c2c11cd7"
   version = "v1.0.0"
 
 [[projects]]
-  digest = "1:260f7ebefc63024c8dfe2c9f1a2935a89fa4213637a1f522f592f80c001cc441"
   name = "github.com/go-openapi/jsonpointer"
   packages = ["."]
-  pruneopts = "NUT"
   revision = "ef5f0afec364d3b9396b7b77b43dbe26bf1f8004"
   version = "v0.17.2"
 
 [[projects]]
-  digest = "1:98abd61947ff5c7c6fcfec5473d02a4821ed3a2dd99a4fbfdb7925b0dd745546"
   name = "github.com/go-openapi/jsonreference"
   packages = ["."]
-  pruneopts = "NUT"
   revision = "8483a886a90412cd6858df4ea3483dce9c8e35a3"
   version = "v0.17.2"
 
 [[projects]]
-  digest = "1:dfab391de021809e0041f0ab5648da6b74dd16a685472a1b8c3dc06b3dca1ee2"
   name = "github.com/go-openapi/spec"
   packages = ["."]
-  pruneopts = "NUT"
   revision = "5bae59e25b21498baea7f9d46e9c147ec106a42e"
   version = "v0.17.2"
 
 [[projects]]
-  digest = "1:983f95b2fae6fe8fdd361738325ed6090f4f3bd15ce4db745e899fb5b0fdfc46"
   name = "github.com/go-openapi/swag"
   packages = ["."]
-  pruneopts = "NUT"
   revision = "5899d5c5e619fda5fa86e14795a835f473ca284c"
   version = "v0.17.2"
 
 [[projects]]
-  digest = "1:8679b8a64f3613e9749c5640c3535c83399b8e69f67ce54d91dc73f6d77373af"
   name = "github.com/gogo/protobuf"
   packages = [
     "proto",
-    "sortkeys",
+    "sortkeys"
   ]
-  pruneopts = "NUT"
   revision = "636bf0302bc95575d69441b25a2603156ffdddf1"
   version = "v1.1.1"
 
 [[projects]]
   branch = "master"
-  digest = "1:e2b86e41f3d669fc36b50d31d32d22c8ac656c75aa5ea89717ce7177e134ff2a"
   name = "github.com/golang/glog"
   packages = ["."]
-  pruneopts = "NUT"
   revision = "23def4e6c14b4da8ac2ed8007337bc5eb5007998"
 
 [[projects]]
-  digest = "1:63ccdfbd20f7ccd2399d0647a7d100b122f79c13bb83da9660b1598396fd9f62"
   name = "github.com/golang/protobuf"
   packages = [
     "proto",
     "ptypes",
     "ptypes/any",
     "ptypes/duration",
-    "ptypes/timestamp",
+    "ptypes/timestamp"
   ]
-  pruneopts = "NUT"
   revision = "aa810b61a9c79d51363740d207bb46cf8e620ed5"
   version = "v1.2.0"
 
 [[projects]]
   branch = "master"
-  digest = "1:05f95ffdfcf651bdb0f05b40b69e7f5663047f8da75c72d58728acb59b5cc107"
   name = "github.com/google/btree"
   packages = ["."]
-  pruneopts = "NUT"
   revision = "4030bb1f1f0c35b30ca7009e9ebd06849dd45306"
 
 [[projects]]
   branch = "master"
-  digest = "1:52c5834e2bebac9030c97cc0798ac11c3aa8a39f098aeb419f142533da6cd3cc"
   name = "github.com/google/gofuzz"
   packages = ["."]
-  pruneopts = "NUT"
   revision = "24818f796faf91cd76ec7bddd72458fbced7a6c1"
 
 [[projects]]
-  digest = "1:a1578f7323eca2b88021fdc9a79a99833d40b12c32a5ea4f284e2fad19ea2657"
   name = "github.com/google/uuid"
   packages = ["."]
-  pruneopts = "NUT"
   revision = "d460ce9f8df2e77fb1ba55ca87fafed96c607494"
   version = "v1.0.0"
 
 [[projects]]
-  digest = "1:06a7dadb7b760767341ffb6c8d377238d68a1226f2b21b5d497d2e3f6ecf6b4e"
   name = "github.com/googleapis/gnostic"
   packages = [
     "OpenAPIv2",
     "compiler",
-    "extensions",
+    "extensions"
   ]
-  pruneopts = "NUT"
   revision = "7c663266750e7d82587642f65e60bc4083f1f84e"
   version = "v0.2.0"
 
 [[projects]]
   branch = "master"
-  digest = "1:7fdf3223c7372d1ced0b98bf53457c5e89d89aecbad9a77ba9fcc6e01f9e5621"
   name = "github.com/gregjones/httpcache"
   packages = [
     ".",
-    "diskcache",
+    "diskcache"
   ]
-  pruneopts = "NUT"
   revision = "9cad4c3443a7200dd6400aef47183728de563a38"
 
 [[projects]]
-  digest = "1:b42cde0e1f3c816dd57f57f7bbcf05ca40263ad96f168714c130c611fc0856a6"
   name = "github.com/hashicorp/golang-lru"
   packages = [
     ".",
-    "simplelru",
+    "simplelru"
   ]
-  pruneopts = "NUT"
   revision = "20f1fb78b0740ba8c3cb143a61e86ba5c8669768"
   version = "v0.5.0"
 
 [[projects]]
-  digest = "1:9a52adf44086cead3b384e5d0dbf7a1c1cce65e67552ee3383a8561c42a18cd3"
   name = "github.com/imdario/mergo"
   packages = ["."]
-  pruneopts = "NUT"
   revision = "9f23e2d6bd2a77f959b2bf6acdbefd708a83a4a4"
   version = "v0.3.6"
 
 [[projects]]
-  digest = "1:8e36686e8b139f8fe240c1d5cf3a145bc675c22ff8e707857cdd3ae17b00d728"
   name = "github.com/json-iterator/go"
   packages = ["."]
-  pruneopts = "NUT"
   revision = "1624edc4454b8682399def8740d46db5e4362ba4"
   version = "v1.1.5"
 
 [[projects]]
-  digest = "1:4059c14e87a2de3a434430340521b5feece186c1469eff0834c29a63870de3ed"
   name = "github.com/konsorten/go-windows-terminal-sequences"
   packages = ["."]
-  pruneopts = "NUT"
   revision = "5c8c8bd35d3832f5d134ae1e1e375b69a4d25242"
   version = "v1.0.1"
 
 [[projects]]
   branch = "master"
-  digest = "1:84a5a2b67486d5d67060ac393aa255d05d24ed5ee41daecd5635ec22657b6492"
   name = "github.com/mailru/easyjson"
   packages = [
     "buffer",
     "jlexer",
-    "jwriter",
+    "jwriter"
   ]
-  pruneopts = "NUT"
   revision = "60711f1a8329503b04e1c88535f419d0bb440bff"
 
 [[projects]]
   branch = "master"
-  digest = "1:7bebc379efb58f69e1a25422674120b143194f61a7c3bcf8e58704d2f2ce8697"
   name = "github.com/matryer/moq"
   packages = [
     ".",
-    "pkg/moq",
+    "pkg/moq"
   ]
-  pruneopts = "NUT"
   revision = "5df7c6ae5624ff5d92cc191e0b730df003c976cb"
 
 [[projects]]
-  digest = "1:5985ef4caf91ece5d54817c11ea25f182697534f8ae6521eadcd628c142ac4b6"
   name = "github.com/matttproud/golang_protobuf_extensions"
   packages = ["pbutil"]
-  pruneopts = "NUT"
   revision = "c12348ce28de40eed0136aa2b644d0ee0650e56c"
   version = "v1.0.1"
 
 [[projects]]
-  digest = "1:2f42fa12d6911c7b7659738758631bec870b7e9b4c6be5444f963cdcfccc191f"
   name = "github.com/modern-go/concurrent"
   packages = ["."]
-  pruneopts = "NUT"
   revision = "bacd9c7ef1dd9b15be4a9909b8ac7a4e313eec94"
   version = "1.0.3"
 
 [[projects]]
-  digest = "1:c6aca19413b13dc59c220ad7430329e2ec454cc310bc6d8de2c7e2b93c18a0f6"
   name = "github.com/modern-go/reflect2"
   packages = ["."]
-  pruneopts = "NUT"
   revision = "4b7aa43c6742a2c18fdef89dd197aaae7dac7ccd"
   version = "1.0.1"
 
 [[projects]]
-  digest = "1:acc97a63f734a3a5898c3c6478f21085e681fb5d610fc20beae36cb8f12fa512"
   name = "github.com/openshift/api"
   packages = [
     "apps/v1",
@@ -266,27 +209,26 @@
     "image/v1",
     "pkg/serialization",
     "route/v1",
-    "template/v1",
+    "template/v1"
   ]
-  pruneopts = "NUT"
   revision = "0d921e363e951d89f583292c60d013c318df64dc"
   version = "v3.9.0"
 
 [[projects]]
-  digest = "1:08d7fbac8c5508ca4736183c3b0574ba79dfb568d3c85cb0fcf2625f8239c14f"
   name = "github.com/openshift/client-go"
   packages = [
+    "apps/clientset/versioned",
+    "apps/clientset/versioned/fake",
     "apps/clientset/versioned/scheme",
     "apps/clientset/versioned/typed/apps/v1",
+    "apps/clientset/versioned/typed/apps/v1/fake",
     "route/clientset/versioned/scheme",
-    "route/clientset/versioned/typed/route/v1",
+    "route/clientset/versioned/typed/route/v1"
   ]
-  pruneopts = "NUT"
   revision = "1fa528d3be060e4c7178eb69e76d37cf7e699e3c"
   version = "v3.9.0"
 
 [[projects]]
-  digest = "1:849835cff411090d517da03b18b08d7eb832ec62fdaf44d6e999e3dd5d9e83bb"
   name = "github.com/operator-framework/operator-sdk"
   packages = [
     "pkg/k8sclient",
@@ -295,131 +237,105 @@
     "pkg/test",
     "pkg/test/e2eutil",
     "pkg/util/k8sutil",
-    "version",
+    "version"
   ]
-  pruneopts = "NUT"
   revision = "e5a0ab096e1a7c0e6b937d2b41707eccb82c3c77"
   version = "v0.0.7"
 
 [[projects]]
   branch = "master"
-  digest = "1:3bf17a6e6eaa6ad24152148a631d18662f7212e21637c2699bff3369b7f00fa2"
   name = "github.com/petar/GoLLRB"
   packages = ["llrb"]
-  pruneopts = "NUT"
   revision = "53be0d36a84c2a886ca057d34b6aa4468df9ccb4"
 
 [[projects]]
-  digest = "1:6c6d91dc326ed6778783cff869c49fb2f61303cdd2ebbcf90abe53505793f3b6"
   name = "github.com/peterbourgon/diskv"
   packages = ["."]
-  pruneopts = "NUT"
   revision = "5f041e8faa004a95c88a202771f4cc3e991971e6"
   version = "v2.0.1"
 
 [[projects]]
-  digest = "1:5cf3f025cbee5951a4ee961de067c8a89fc95a5adabead774f82822efabab121"
   name = "github.com/pkg/errors"
   packages = ["."]
-  pruneopts = "NUT"
   revision = "645ef00459ed84a119197bfb8d8205042c6df63d"
   version = "v0.8.0"
 
 [[projects]]
-  digest = "1:a8512715947d49f24e6aa2d0fdd06f46bdd8d2e792517ba0ac95a2c089eaae28"
   name = "github.com/prometheus/client_golang"
   packages = [
     "prometheus",
     "prometheus/internal",
-    "prometheus/promhttp",
+    "prometheus/promhttp"
   ]
-  pruneopts = "NUT"
   revision = "abad2d1bd44235a26707c172eab6bca5bf2dbad3"
   version = "v0.9.1"
 
 [[projects]]
   branch = "master"
-  digest = "1:2d5cd61daa5565187e1d96bae64dbbc6080dacf741448e9629c64fd93203b0d4"
   name = "github.com/prometheus/client_model"
   packages = ["go"]
-  pruneopts = "NUT"
   revision = "5c3871d89910bfb32f5fcab2aa4b9ec68e65a99f"
 
 [[projects]]
   branch = "master"
-  digest = "1:06375f3b602de9c99fa99b8484f0e949fd5273e6e9c6592b5a0dd4cd9085f3ea"
   name = "github.com/prometheus/common"
   packages = [
     "expfmt",
     "internal/bitbucket.org/ww/goautoneg",
-    "model",
+    "model"
   ]
-  pruneopts = "NUT"
   revision = "7e9e6cabbd393fc208072eedef99188d0ce788b6"
 
 [[projects]]
   branch = "master"
-  digest = "1:102dea0c03a915acfc634b7c67f2662012b5483b56d9025e33f5188e112759b6"
   name = "github.com/prometheus/procfs"
   packages = [
     ".",
     "internal/util",
     "nfs",
-    "xfs",
+    "xfs"
   ]
-  pruneopts = "NUT"
   revision = "185b4288413d2a0dd0806f78c90dde719829e5ae"
 
 [[projects]]
-  digest = "1:d848e2bdc690ea54c4b49894b67a05db318a97ee6561879b814c2c1f82f61406"
   name = "github.com/sirupsen/logrus"
   packages = ["."]
-  pruneopts = "NUT"
   revision = "bcd833dfe83d3cebad139e4a29ed79cb2318bf95"
   version = "v1.2.0"
 
 [[projects]]
-  digest = "1:9d8420bbf131d1618bde6530af37c3799340d3762cc47210c1d9532a4c3a2779"
   name = "github.com/spf13/pflag"
   packages = ["."]
-  pruneopts = "NUT"
   revision = "298182f68c66c05229eb03ac171abe6e309ee79a"
   version = "v1.0.3"
 
 [[projects]]
   branch = "master"
-  digest = "1:3f3a05ae0b95893d90b9b3b5afdb79a9b3d96e4e36e099d841ae602e4aca0da8"
   name = "golang.org/x/crypto"
   packages = ["ssh/terminal"]
-  pruneopts = "NUT"
   revision = "e4dc69e5b2fd71dcaf8bd5d054eb936deb78d1fa"
 
 [[projects]]
   branch = "master"
-  digest = "1:e44fa0101bdbb14eb87a9c5d13c594911117e7695e54b3474615231a012bb2c3"
   name = "golang.org/x/net"
   packages = [
     "http/httpguts",
     "http2",
     "http2/hpack",
-    "idna",
+    "idna"
   ]
-  pruneopts = "NUT"
   revision = "03003ca0c849e57b6ea29a4bab8d3cb6e4d568fe"
 
 [[projects]]
   branch = "master"
-  digest = "1:6eac76de26138eb5049ffa3f3a8d4cf394cf626812b7d9b31308301e24bc9840"
   name = "golang.org/x/sys"
   packages = [
     "unix",
-    "windows",
+    "windows"
   ]
-  pruneopts = "NUT"
   revision = "66b7b1311ac80bbafcd2daeef9a5e6e2cd1e2399"
 
 [[projects]]
-  digest = "1:e33513a825fcd765e97b5de639a2f7547542d1a8245df0cef18e1fd390b778a9"
   name = "golang.org/x/text"
   packages = [
     "collate",
@@ -436,23 +352,19 @@
     "unicode/cldr",
     "unicode/norm",
     "unicode/rangetable",
-    "width",
+    "width"
   ]
-  pruneopts = "NUT"
   revision = "f21a4dfb5e38f5895301dc265a8def02365cc3d0"
   version = "v0.3.0"
 
 [[projects]]
   branch = "master"
-  digest = "1:9fdc2b55e8e0fafe4b41884091e51e77344f7dc511c5acedcfd98200003bff90"
   name = "golang.org/x/time"
   packages = ["rate"]
-  pruneopts = "NUT"
   revision = "85acf8d2951cb2a3bde7632f9ff273ef0379bcbd"
 
 [[projects]]
   branch = "master"
-  digest = "1:d49522116282853e738a30fe1278bd22d6ca5cbcffba2e9b7e9e41760cec6dcd"
   name = "golang.org/x/tools"
   packages = [
     "go/ast/astutil",
@@ -461,29 +373,23 @@
     "go/loader",
     "imports",
     "internal/fastwalk",
-    "internal/gopathwalk",
+    "internal/gopathwalk"
   ]
-  pruneopts = "NUT"
   revision = "a28dfb48e06b2296b66678872c2cb638f0304f20"
 
 [[projects]]
-  digest = "1:2d1fbdc6777e5408cabeb02bf336305e724b925ff4546ded0fa8715a7267922a"
   name = "gopkg.in/inf.v0"
   packages = ["."]
-  pruneopts = "NUT"
   revision = "d2d2541c53f18d2a059457998ce2876cc8e67cbf"
   version = "v0.9.1"
 
 [[projects]]
-  digest = "1:7c95b35057a0ff2e19f707173cc1a947fa43a6eb5c4d300d196ece0334046082"
   name = "gopkg.in/yaml.v2"
   packages = ["."]
-  pruneopts = "NUT"
   revision = "5420a8b6744d3b0345ab293f6fcba19c978f1183"
   version = "v2.2.1"
 
 [[projects]]
-  digest = "1:ef716a2116d8a040e16fbcd7fca71d3354915a94720de6af22c7a09970234296"
   name = "k8s.io/api"
   packages = [
     "admissionregistration/v1alpha1",
@@ -514,24 +420,20 @@
     "settings/v1alpha1",
     "storage/v1",
     "storage/v1alpha1",
-    "storage/v1beta1",
+    "storage/v1beta1"
   ]
-  pruneopts = "NUT"
   revision = "2d6f90ab1293a1fb871cf149423ebb72aa7423aa"
 
 [[projects]]
-  digest = "1:8407b3e64b4d61ea830fcf3f0417bbd1726f744b7fc13cb8c5d70dcda88749b8"
   name = "k8s.io/apiextensions-apiserver"
   packages = [
     "pkg/apis/apiextensions",
     "pkg/apis/apiextensions/v1beta1",
-    "pkg/client/clientset/clientset/scheme",
+    "pkg/client/clientset/clientset/scheme"
   ]
-  pruneopts = "NUT"
   revision = "408db4a50408e2149acbd657bceb2480c13cb0a4"
 
 [[projects]]
-  digest = "1:1863cb213bf50c1505c7ef97e78ce4e641e4fda9b4e7dc666ad57b094fdaffe8"
   name = "k8s.io/apimachinery"
   packages = [
     "pkg/api/errors",
@@ -574,13 +476,11 @@
     "pkg/version",
     "pkg/watch",
     "third_party/forked/golang/json",
-    "third_party/forked/golang/reflect",
+    "third_party/forked/golang/reflect"
   ]
-  pruneopts = "NUT"
   revision = "103fd098999dc9c0c88536f5c9ad2e5da39373ae"
 
 [[projects]]
-  digest = "1:c9e65e7c2f6bacbb33974bd76a7e1167cbcc06fa9d2ad78d0acac4d1cc9245e1"
   name = "k8s.io/client-go"
   packages = [
     "discovery",
@@ -674,13 +574,11 @@
     "util/homedir",
     "util/integer",
     "util/retry",
-    "util/workqueue",
+    "util/workqueue"
   ]
-  pruneopts = "NUT"
   revision = "1f13a808da65775f22cbf47862c4e5898d8f4ca1"
 
 [[projects]]
-  digest = "1:8ab487a323486c8bbbaa3b689850487fdccc6cbea8690620e083b2d230a4447e"
   name = "k8s.io/code-generator"
   packages = [
     "cmd/client-gen",
@@ -706,14 +604,12 @@
     "cmd/lister-gen/generators",
     "cmd/openapi-gen",
     "cmd/openapi-gen/args",
-    "pkg/util",
+    "pkg/util"
   ]
-  pruneopts = "T"
   revision = "6702109cc68eb6fe6350b83e14407c8d7309fd1a"
 
 [[projects]]
   branch = "master"
-  digest = "1:da31d8be5af84b69ef83b212d833d8e10930cd9e8a876780a20099ea306c4c13"
   name = "k8s.io/gengo"
   packages = [
     "args",
@@ -723,22 +619,18 @@
     "generator",
     "namer",
     "parser",
-    "types",
+    "types"
   ]
-  pruneopts = "NUT"
   revision = "51747d6e00da1fc578d5a333a93bb2abcbce7a95"
 
 [[projects]]
   branch = "master"
-  digest = "1:9cc257b3c9ff6a0158c9c661ab6eebda1fe8a4a4453cd5c4044dc9a2ebfb992b"
   name = "k8s.io/klog"
   packages = ["."]
-  pruneopts = "NUT"
   revision = "b9b56d5dfc9208f60ea747056670942d8b0afdc8"
 
 [[projects]]
   branch = "master"
-  digest = "1:67864daa8a5832b6a0a81969fd17dc00552c5970f204baa2b30f922b603f89f7"
   name = "k8s.io/kube-openapi"
   packages = [
     "cmd/openapi-gen/args",
@@ -746,76 +638,22 @@
     "pkg/generators",
     "pkg/generators/rules",
     "pkg/util/proto",
-    "pkg/util/sets",
+    "pkg/util/sets"
   ]
-  pruneopts = "NUT"
   revision = "a9a16210091c9a2b6a937e06a182955c03654c4c"
 
 [[projects]]
-  digest = "1:8131554e28cf80cddfaceaf2339153db5985a12a3da2187c80cc59149f21ee0c"
   name = "sigs.k8s.io/controller-runtime"
   packages = [
     "pkg/client",
-    "pkg/client/apiutil",
+    "pkg/client/apiutil"
   ]
-  pruneopts = "NUT"
   revision = "5fd1e9e9fac5261e9ad9d47c375afc014fc31d21"
   version = "v0.1.7"
 
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  input-imports = [
-    "github.com/Jeffail/gabs",
-    "github.com/ghodss/yaml",
-    "github.com/google/uuid",
-    "github.com/matryer/moq",
-    "github.com/openshift/api/apps/v1",
-    "github.com/openshift/api/authorization/v1",
-    "github.com/openshift/api/build/v1",
-    "github.com/openshift/api/image/v1",
-    "github.com/openshift/api/route/v1",
-    "github.com/openshift/api/template/v1",
-    "github.com/openshift/client-go/apps/clientset/versioned/typed/apps/v1",
-    "github.com/openshift/client-go/route/clientset/versioned/typed/route/v1",
-    "github.com/operator-framework/operator-sdk/pkg/k8sclient",
-    "github.com/operator-framework/operator-sdk/pkg/sdk",
-    "github.com/operator-framework/operator-sdk/pkg/test",
-    "github.com/operator-framework/operator-sdk/pkg/test/e2eutil",
-    "github.com/operator-framework/operator-sdk/pkg/util/k8sutil",
-    "github.com/operator-framework/operator-sdk/version",
-    "github.com/pkg/errors",
-    "github.com/sirupsen/logrus",
-    "k8s.io/api/batch/v1",
-    "k8s.io/api/batch/v1beta1",
-    "k8s.io/api/core/v1",
-    "k8s.io/apimachinery/pkg/api/errors",
-    "k8s.io/apimachinery/pkg/api/meta",
-    "k8s.io/apimachinery/pkg/apis/meta/v1",
-    "k8s.io/apimachinery/pkg/apis/meta/v1/unstructured",
-    "k8s.io/apimachinery/pkg/runtime",
-    "k8s.io/apimachinery/pkg/runtime/schema",
-    "k8s.io/apimachinery/pkg/runtime/serializer",
-    "k8s.io/apimachinery/pkg/runtime/serializer/json",
-    "k8s.io/apimachinery/pkg/runtime/serializer/versioning",
-    "k8s.io/apimachinery/pkg/types",
-    "k8s.io/apimachinery/pkg/util/json",
-    "k8s.io/apimachinery/pkg/util/sets",
-    "k8s.io/apimachinery/pkg/util/wait",
-    "k8s.io/apimachinery/pkg/util/yaml",
-    "k8s.io/client-go/dynamic",
-    "k8s.io/client-go/kubernetes",
-    "k8s.io/client-go/kubernetes/fake",
-    "k8s.io/client-go/kubernetes/typed/core/v1",
-    "k8s.io/client-go/rest",
-    "k8s.io/code-generator/cmd/client-gen",
-    "k8s.io/code-generator/cmd/conversion-gen",
-    "k8s.io/code-generator/cmd/deepcopy-gen",
-    "k8s.io/code-generator/cmd/defaulter-gen",
-    "k8s.io/code-generator/cmd/informer-gen",
-    "k8s.io/code-generator/cmd/lister-gen",
-    "k8s.io/code-generator/cmd/openapi-gen",
-    "k8s.io/gengo/args",
-  ]
+  inputs-digest = "c86720a8bbcd3868d45f8b6ea341266ecb2bad7df713d4ed9e330777aa8eecad"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/pkg/apis/aerogear/v1alpha1/types.go
+++ b/pkg/apis/aerogear/v1alpha1/types.go
@@ -238,7 +238,8 @@ type GenericStatus struct {
 
 type KeycloakStatus struct {
 	GenericStatus
-	MonitoringResourcesCreated bool `json:"monitoringResourcesCreated"`
+	MonitoringResourcesCreated bool  `json:"monitoringResourcesCreated"`
+	Replicas                   int32 `json:"replicas"`
 }
 
 type StatusPhase string
@@ -257,6 +258,7 @@ var (
 	PhaseDeprovisionFailed     StatusPhase = "deprovisionFailed"
 	PhaseCredentialsPending    StatusPhase = "credentialsPending"
 	PhaseAwaitProvision        StatusPhase = "awaitProvision"
+	PhaseUpgrading             StatusPhase = "upgrading"
 	PhaseProvision             StatusPhase = "provision"
 )
 

--- a/pkg/keycloak/keycloak.go
+++ b/pkg/keycloak/keycloak.go
@@ -28,6 +28,7 @@ const (
 	SSO_TEMPLATE_PATH         = "deploy/template"
 	SSO_TEMPLATE_PATH_ENV_VAR = "TEMPLATE_DIR"
 	SSO_VERSION               = "v7.3.2.GA"
+	SSO_IMAGE_STREAM          = "redhat-sso73-openshift:1.0"
 )
 
 //go:generate moq -out sdkCruder_moq.go . SdkCruder
@@ -121,6 +122,16 @@ func (h *Reconciler) Handle(ctx context.Context, object interface{}, deleted boo
 		return h.sdkCrud.Update(kcState)
 	}
 
+	kcState, err := h.phaseHandler.Upgrade(kc)
+	if err != nil {
+		return errors.Wrap(err, "upgrading failed")
+	}
+	if kcState == nil {
+		return nil
+	}
+	if err := h.sdkCrud.Update(kcState); err != nil {
+		return errors.Wrap(err, "failed to update state")
+	}
 	switch kc.Status.Phase {
 	case v1alpha1.NoPhase:
 		kcState, err := h.phaseHandler.Initialise(kc)

--- a/pkg/keycloak/phaseHandler.go
+++ b/pkg/keycloak/phaseHandler.go
@@ -3,6 +3,7 @@ package keycloak
 import (
 	"fmt"
 	"github.com/integr8ly/keycloak-operator/pkg/util"
+	"github.com/sirupsen/logrus"
 	batchv1 "k8s.io/api/batch/v1"
 	"k8s.io/api/batch/v1beta1"
 	"strings"
@@ -93,6 +94,109 @@ func (ph *phaseHandler) Accepted(sso *v1alpha1.Keycloak) (*v1alpha1.Keycloak, er
 		kc.Status.Phase = v1alpha1.PhaseProvision
 	}
 	return kc, nil
+}
+
+// Upgrade will perform the necessary actions to do the upgrade for an in place sso instance
+// Note we rely on imagestreams that the operator itself does not install (these are installed currently by the installer in the openshift ns )
+func (ph *phaseHandler) Upgrade(sso *v1alpha1.Keycloak) (*v1alpha1.Keycloak, error) {
+	cpSSO := sso.DeepCopy()
+	dc, err := ph.ocDCClient.DeploymentConfigs(cpSSO.Namespace).Get(SSO_APPLICATION_NAME, v12.GetOptions{})
+	if err != nil {
+		return cpSSO, errors.Wrap(err, "failed to get current deploymentconfig for sso")
+	}
+	if !CanUpgrade(cpSSO.Status.Version) || (cpSSO.Status.Phase != v1alpha1.PhaseUpgrading && cpSSO.Status.Phase != v1alpha1.PhaseReconcile) {
+		logrus.Debug("not upgrading from version ", cpSSO.Status.Version, " in phase ", cpSSO.Status.Phase)
+		cpSSO.Status.Message = "not upgrading. Version is either current or there is no upgrade path."
+		return cpSSO, nil
+	}
+	if cpSSO.Status.Phase == v1alpha1.PhaseReconcile {
+		logrus.Debug("marking for upgrade ", cpSSO.Status.Version, cpSSO.Status.Phase)
+		cpSSO.Status.Phase = v1alpha1.PhaseUpgrading
+		cpSSO.Status.Replicas = dc.Spec.Replicas
+		return cpSSO, nil
+	}
+
+	logrus.Info(" starting upgrade")
+
+	// scale down pod  ( we need to do this for RH-SSO to allow DB schema to be applied by the new image)
+	dc, err = ph.ocDCClient.DeploymentConfigs(cpSSO.Namespace).Get(SSO_APPLICATION_NAME, v12.GetOptions{})
+	if err != nil {
+		return cpSSO, errors.Wrap(err, "failed to get current scale for sso")
+	}
+
+	if !DeploymentUpgraded(dc.DeepCopy()) {
+		if dc.Spec.Replicas > 0 {
+			logrus.Debug("scaling down rh-sso")
+			newScale := dc.DeepCopy()
+			newScale.Spec.Replicas = 0
+			dc, err = ph.ocDCClient.DeploymentConfigs(cpSSO.Namespace).Update(newScale)
+			if err != nil {
+				return cpSSO, errors.Wrap(err, "failed to update deploymentconfig for sso during upgrade when trying to scale down ")
+			}
+		}
+		// ensure fresh copy
+		dc, err = ph.ocDCClient.DeploymentConfigs(cpSSO.Namespace).Get(SSO_APPLICATION_NAME, v12.GetOptions{})
+		if err != nil {
+			return cpSSO, errors.Wrap(err, "failed to get current dc for sso during upgrade")
+		}
+		if dc.Status.Replicas != 0 && dc.Status.AvailableReplicas != 0 {
+			logrus.Debug("not yet scaled down waiting")
+			return cpSSO, nil
+		}
+
+		logrus.Debug("upgrading deployment config")
+		upgradedDc := UpgradeDeploymentConfig(dc)
+		dc, err = ph.ocDCClient.DeploymentConfigs(cpSSO.Namespace).Update(upgradedDc)
+		if err != nil {
+			return cpSSO, errors.Wrap(err, "failed to update deployment config for sso during upgrade")
+		}
+	}
+	// dc upgraded moving on to service
+	svc, err := ph.k8sClient.CoreV1().Services(cpSSO.Namespace).Get(fmt.Sprintf("%s-ping", SSO_APPLICATION_NAME), v12.GetOptions{})
+	if err != nil {
+		return cpSSO, errors.Wrap(err, "failed to get the ping service during upgrade")
+	}
+
+	if !ServiceUpgraded(svc) {
+		logrus.Debug("service being upgraded ", svc.Name)
+		upgradedSvc := UpgradeService(svc.DeepCopy())
+		if _, err := ph.k8sClient.CoreV1().Services(upgradedSvc.Namespace).Update(upgradedSvc); err != nil {
+			return cpSSO, errors.Wrap(err, "failed to update the service "+upgradedSvc.Name+" during upgrade")
+		}
+	}
+	logrus.Debug("upgrade completed scaling the replicas back up to original")
+	dc, err = ph.ocDCClient.DeploymentConfigs(cpSSO.Namespace).Get(SSO_APPLICATION_NAME, v12.GetOptions{})
+	if err != nil {
+		return cpSSO, errors.Wrap(err, "failed to get current scale for sso")
+	}
+	if dc.Spec.Replicas == 0 {
+		logrus.Debug("scaling replicas to ", cpSSO.Status.Replicas)
+		dc.Spec.Replicas = cpSSO.Status.Replicas
+		if _, err := ph.ocDCClient.DeploymentConfigs(cpSSO.Namespace).Update(dc); err != nil {
+			return cpSSO, errors.Wrap(err, "failed to update sso deploymentconfig after replacing the image stream trigger and scaling back to 1")
+		}
+	}
+
+	if dc.Status.Replicas != cpSSO.Status.Replicas && dc.Status.AvailableReplicas != cpSSO.Status.Replicas {
+		logrus.Debug("not yet scaled up waiting")
+		return cpSSO, nil
+	}
+	// check pods are ready
+	pods, err := ph.k8sClient.CoreV1().Pods(cpSSO.Namespace).List(v12.ListOptions{LabelSelector: "application=sso"})
+	if err != nil {
+		return cpSSO, errors.Wrap(err, "failed waiting for sso pod to be ready")
+	}
+	for _, p := range pods.Items {
+		for _, ps := range p.Status.ContainerStatuses {
+			if !ps.Ready {
+				logrus.Debug("containers not ready yet")
+				return cpSSO, nil
+			}
+		}
+	}
+	cpSSO.Status.Version = SSO_VERSION
+	cpSSO.Status.Phase = v1alpha1.PhaseReconcile
+	return cpSSO, nil
 }
 
 func (ph *phaseHandler) Provision(sso *v1alpha1.Keycloak) (*v1alpha1.Keycloak, error) {

--- a/pkg/keycloak/upgrade.go
+++ b/pkg/keycloak/upgrade.go
@@ -1,0 +1,150 @@
+package keycloak
+
+import (
+	v1 "github.com/openshift/api/apps/v1"
+	"github.com/sirupsen/logrus"
+	cv1 "k8s.io/api/core/v1"
+	"regexp"
+)
+
+func CanUpgrade(version string) bool {
+	// we will handle upgrade for any 7.2.x version
+	r := regexp.MustCompile("^v7.2.*.GA$")
+	return r.MatchString(version)
+}
+
+func DeploymentUpgraded(dc *v1.DeploymentConfig) bool {
+	if !triggersUpgraded(dc) {
+		logrus.Debug("triggers are not upgraded")
+		return false
+	}
+	if !volumesUpgraded(dc) {
+		logrus.Debug("volumes are not upgraded")
+		return false
+	}
+
+	return envVarsAndVolumeMountsUpgraded(dc)
+}
+
+func triggersUpgraded(dc *v1.DeploymentConfig) bool {
+	for _, t := range dc.Spec.Triggers {
+		if t.Type == v1.DeploymentTriggerOnImageChange {
+			if t.ImageChangeParams.From.Name == SSO_IMAGE_STREAM {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func volumesUpgraded(dc *v1.DeploymentConfig) bool {
+	for _, v := range dc.Spec.Template.Spec.Volumes {
+		if v.Name == "sso-x509-jgroups-volume" {
+			return true
+		}
+	}
+	return false
+}
+
+func envVarsAndVolumeMountsUpgraded(dc *v1.DeploymentConfig) bool {
+	jgroupEnvFound := false
+	ssoHostEnvFound := false
+	for _, c := range dc.Spec.Template.Spec.Containers {
+		if c.Name == SSO_APPLICATION_NAME {
+			volumeMountFound := false
+			for _, vm := range c.VolumeMounts {
+				if vm.Name == "sso-x509-jgroups-volume" {
+					volumeMountFound = true
+				}
+			}
+			if !volumeMountFound {
+				logrus.Debug("volume mound missing")
+				return false
+			}
+			for _, e := range c.Env {
+				if e.Name == "SSO_HOSTNAME" {
+					ssoHostEnvFound = true
+				}
+				if e.Name == "JGROUPS_ENCRYPT_PROTOCOL" {
+					jgroupEnvFound = true
+				}
+			}
+			break
+		}
+	}
+	if jgroupEnvFound == true || !ssoHostEnvFound {
+		logrus.Debug("env vars are not correct")
+		return false
+	}
+	return true
+}
+
+func ServiceUpgraded(service *cv1.Service) bool {
+	_, ok := service.ObjectMeta.Annotations["service.alpha.openshift.io/serving-cert-secret-name"]
+	return ok
+}
+
+func UpgradeDeploymentConfig(dc *v1.DeploymentConfig) *v1.DeploymentConfig {
+	for _, t := range dc.Spec.Triggers {
+		if t.Type == v1.DeploymentTriggerOnImageChange {
+			t.ImageChangeParams.From.Name = SSO_IMAGE_STREAM
+		}
+	}
+	volumeExists := false
+	volumeName := "sso-x509-jgroups-volume"
+	for _, v := range dc.Spec.Template.Spec.Volumes {
+		if v.Name == volumeName {
+			volumeExists = true
+			break
+		}
+	}
+	if !volumeExists {
+		dc.Spec.Template.Spec.Volumes = append(dc.Spec.Template.Spec.Volumes, cv1.Volume{
+			Name: volumeName,
+			VolumeSource: cv1.VolumeSource{
+				Secret: &cv1.SecretVolumeSource{
+					SecretName: "sso-x509-jgroups-secret",
+				},
+			},
+		})
+	}
+	for i, c := range dc.Spec.Template.Spec.Containers {
+		if c.Name == SSO_APPLICATION_NAME {
+			// check if the volume already exists
+			volumeMountName := "sso-x509-jgroups-volume"
+			volumeMountExists := false
+			for _, vm := range dc.Spec.Template.Spec.Containers[i].VolumeMounts {
+				if vm.Name == volumeMountName {
+					volumeMountExists = true
+					break
+				}
+			}
+			if !volumeMountExists {
+				dc.Spec.Template.Spec.Containers[i].VolumeMounts = append(c.VolumeMounts, cv1.VolumeMount{
+					Name:      volumeMountName,
+					MountPath: "/etc/x509/jgroups",
+					ReadOnly:  true,
+				})
+			}
+			var ei = 0
+			var e = cv1.EnvVar{}
+			for ei, e = range c.Env {
+				if e.Name == "JGROUPS_ENCRYPT_PROTOCOL" {
+					break
+				}
+			}
+			dc.Spec.Template.Spec.Containers[i].Env = append(c.Env[:ei], c.Env[ei+1:]...)
+			dc.Spec.Template.Spec.Containers[i].Env = append(dc.Spec.Template.Spec.Containers[i].Env, cv1.EnvVar{
+				Name:  "SSO_HOSTNAME",
+				Value: "",
+			})
+			return dc
+		}
+	}
+	return dc
+}
+
+func UpgradeService(s *cv1.Service) *cv1.Service {
+	s.ObjectMeta.Annotations["service.alpha.openshift.io/serving-cert-secret-name"] = "sso-x509-jgroups-secret"
+	return s
+}

--- a/pkg/keycloak/upgrade_test.go
+++ b/pkg/keycloak/upgrade_test.go
@@ -1,0 +1,338 @@
+package keycloak_test
+
+import (
+	"fmt"
+	"github.com/integr8ly/keycloak-operator/pkg/keycloak"
+	v1 "github.com/openshift/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	v12 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"testing"
+)
+
+func TestCanUpgrade(t *testing.T) {
+	cases := []struct {
+		Name     string
+		Versions []string
+		Expected bool
+	}{
+		{
+			Name:     "Test Should upgrade",
+			Versions: []string{"v7.2.11.GA", "v7.2.1.GA"},
+			Expected: true,
+		},
+		{
+			Name:     "Test Should Not upgrade",
+			Versions: []string{"v7.3.2.GA", "v7.3.1.GA", "v7.3.0.GA", "v7.2.0-ALPHA"},
+			Expected: false,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.Name, func(t *testing.T) {
+			for _, v := range tc.Versions {
+				ex := keycloak.CanUpgrade(v)
+				if ex != tc.Expected {
+					t.Fatal("expected ", tc.Expected, " but got ", ex)
+				}
+			}
+		})
+	}
+}
+
+func TestUpgradeService(t *testing.T) {
+	cases := []struct {
+		Name     string
+		SVC      *corev1.Service
+		Validate func(t *testing.T, s *corev1.Service)
+	}{
+		{
+			Name: "test service upgraded as expected",
+			SVC: &corev1.Service{
+				ObjectMeta: v12.ObjectMeta{Annotations: map[string]string{}},
+			},
+			Validate: func(t *testing.T, s *corev1.Service) {
+				v, ok := s.Annotations["service.alpha.openshift.io/serving-cert-secret-name"]
+				if !ok {
+					t.Fatal("expected the annotation ", "service.alpha.openshift.io/serving-cert-secret-name", "to be present")
+				}
+				if v != "sso-x509-jgroups-secret" {
+					t.Fatal("expected the annotation service.alpha.openshift.io/serving-cert-secret-name to be sso-x509-jgroups-secret but it was  ", v)
+				}
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.Name, func(t *testing.T) {
+			tc.Validate(t, keycloak.UpgradeService(tc.SVC))
+		})
+	}
+}
+
+func TestDeploymentUpgraded(t *testing.T) {
+	dc := &v1.DeploymentConfig{
+		Spec: v1.DeploymentConfigSpec{
+			Triggers: v1.DeploymentTriggerPolicies{
+				v1.DeploymentTriggerPolicy{
+					Type: v1.DeploymentTriggerOnImageChange,
+					ImageChangeParams: &v1.DeploymentTriggerImageChangeParams{
+						From: corev1.ObjectReference{
+							Name: keycloak.SSO_IMAGE_STREAM,
+						},
+					},
+				},
+			},
+			Template: &corev1.PodTemplateSpec{
+				Spec: corev1.PodSpec{
+					Volumes: []corev1.Volume{
+						corev1.Volume{Name: "sso-x509-jgroups-volume"},
+						corev1.Volume{},
+					},
+					Containers: []corev1.Container{
+						corev1.Container{
+							Name: keycloak.SSO_APPLICATION_NAME,
+							VolumeMounts: []corev1.VolumeMount{
+								corev1.VolumeMount{Name: "sso-x509-jgroups-volume"},
+								corev1.VolumeMount{},
+							},
+							Env: []corev1.EnvVar{
+								corev1.EnvVar{Name: "SSO_HOSTNAME"},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	cases := []struct {
+		Name     string
+		Expect   bool
+		DC       *v1.DeploymentConfig
+		ModifyDC func(config *v1.DeploymentConfig) *v1.DeploymentConfig
+	}{
+		{
+			Name:   "test an upgraded deployment return true",
+			DC:     dc,
+			Expect: true,
+		},
+		{
+			Name:   "test missing volumes in deployment return false",
+			DC:     dc,
+			Expect: false,
+			ModifyDC: func(config *v1.DeploymentConfig) *v1.DeploymentConfig {
+				cp := config.DeepCopy()
+				cp.Spec.Template.Spec.Volumes = []corev1.Volume{}
+				return cp
+			},
+		},
+		{
+			Name:   "test missing env var return false",
+			DC:     dc,
+			Expect: false,
+			ModifyDC: func(config *v1.DeploymentConfig) *v1.DeploymentConfig {
+				cp := config.DeepCopy()
+				cp.Spec.Template.Spec.Containers[0].Env = []corev1.EnvVar{}
+				return cp
+			},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.Name, func(t *testing.T) {
+			dc := tc.DC
+			if tc.ModifyDC != nil {
+				dc = tc.ModifyDC(tc.DC)
+			}
+			fmt.Println(dc.Spec.Template.Spec.Volumes)
+			upgraded := keycloak.DeploymentUpgraded(dc)
+			if upgraded != tc.Expect {
+				t.Fatalf("expected to get %v but got %v for DeploymentUpgraded ", tc.Expect, upgraded)
+			}
+		})
+	}
+}
+
+func TestServiceUpgraded(t *testing.T) {
+	cases := []struct {
+		Name   string
+		Expect bool
+		SVC    *corev1.Service
+	}{
+		{
+			Name:   "test service is upgraded",
+			Expect: true,
+			SVC: &corev1.Service{
+				ObjectMeta: v12.ObjectMeta{
+					Annotations: map[string]string{"service.alpha.openshift.io/serving-cert-secret-name": "sso-x509-jgroups-secret"},
+				},
+			},
+		},
+		{
+			Name:   "test service should is not upgraded",
+			Expect: false,
+			SVC: &corev1.Service{
+				ObjectMeta: v12.ObjectMeta{
+					Annotations: map[string]string{},
+				},
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.Name, func(t *testing.T) {
+			upgraded := keycloak.ServiceUpgraded(tc.SVC)
+			if upgraded != tc.Expect {
+				t.Fatalf("Expected to get %v but got %v ", tc.Expect, upgraded)
+			}
+		})
+	}
+}
+
+func TestUpgradeDeploymentConfig(t *testing.T) {
+	testDC := &v1.DeploymentConfig{
+		Spec: v1.DeploymentConfigSpec{
+			Triggers: []v1.DeploymentTriggerPolicy{
+				v1.DeploymentTriggerPolicy{
+					Type: v1.DeploymentTriggerOnImageChange,
+					ImageChangeParams: &v1.DeploymentTriggerImageChangeParams{
+						From: corev1.ObjectReference{
+							Name: "test",
+						},
+					},
+				},
+			},
+			Template: &corev1.PodTemplateSpec{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						corev1.Container{
+							Name:         keycloak.SSO_APPLICATION_NAME,
+							VolumeMounts: []corev1.VolumeMount{},
+							Env: []corev1.EnvVar{
+								corev1.EnvVar{
+									Name:  "JGROUPS_ENCRYPT_PROTOCOL",
+									Value: "test",
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	cases := []struct {
+		Name     string
+		DC       func() *v1.DeploymentConfig
+		Validate func(t *testing.T, d *v1.DeploymentConfig)
+	}{
+		{
+			Name: "Test deployment config updated correctly",
+			DC: func() *v1.DeploymentConfig {
+				return testDC
+			},
+			Validate: func(t *testing.T, dc *v1.DeploymentConfig) {
+				imageTriggerFound := false
+				for _, tr := range dc.Spec.Triggers {
+					if tr.Type == v1.DeploymentTriggerOnImageChange {
+						imageTriggerFound = true
+						if tr.ImageChangeParams.From.Name != keycloak.SSO_IMAGE_STREAM {
+							t.Fatal("image stream name should be set to ", keycloak.SSO_IMAGE_STREAM, " but is set to ", tr.ImageChangeParams.From.Name)
+						}
+					}
+				}
+				if !imageTriggerFound {
+					t.Fatal("no image stream trigger found for on image change")
+				}
+				volumeFound := false
+				for _, v := range dc.Spec.Template.Spec.Volumes {
+					if v.Name == "sso-x509-jgroups-volume" {
+						volumeFound = true
+						if v.Secret.SecretName != "sso-x509-jgroups-secret" {
+							t.Fatal("expected the volume to be from a secret named sso-x509-jgroups-secret")
+						}
+					}
+
+				}
+				if !volumeFound {
+					t.Fatal("did not find new volume after upgrade ")
+				}
+				containerFound := false
+				volumeMountFound := false
+				newContainerEnvFound := false
+
+				for _, c := range dc.Spec.Template.Spec.Containers {
+					if c.Name == keycloak.SSO_APPLICATION_NAME {
+						containerFound = true
+						for _, vm := range c.VolumeMounts {
+							if vm.Name == "sso-x509-jgroups-volume" {
+								volumeMountFound = true
+								if !vm.ReadOnly {
+									t.Fatal("expected the volume mount ", "sso-x509-jgroups-volume", "to be read only")
+								}
+								if vm.MountPath != "/etc/x509/jgroups" {
+									t.Fatal("epected the mount path to be ", "/etc/x509/jgroups", "but it was "+vm.MountPath)
+								}
+							}
+						}
+						for _, ev := range c.Env {
+							if ev.Name == "SSO_HOSTNAME" {
+								newContainerEnvFound = true
+							}
+							if ev.Name == "JGROUPS_ENCRYPT_PROTOCOL" {
+								t.Fatal("did not expect to find JGROUPS_ENCRYPT_PROTOCOL in the env")
+							}
+						}
+					}
+				}
+				if !containerFound {
+					t.Fatal("expected the ", keycloak.SSO_APPLICATION_NAME, " container but it was not present")
+				}
+				if !volumeMountFound {
+					t.Fatal("expected to find a new volume mount named ", "sso-x509-jgroups-volume", "but found none")
+				}
+				if !newContainerEnvFound {
+					t.Fatal("expected to find a new env var SSO_HOSTNAME but it was missing")
+				}
+
+			},
+		},
+		{
+			Name: "test volume and volume only exists once",
+			DC: func() *v1.DeploymentConfig {
+				dcCopy := testDC.DeepCopy()
+				dcCopy.Spec.Template.Spec.Volumes = []corev1.Volume{
+					corev1.Volume{
+						Name: "sso-x509-jgroups-volume",
+						VolumeSource: corev1.VolumeSource{
+							Secret: &corev1.SecretVolumeSource{
+								SecretName: "sso-x509-jgroups-secret",
+							},
+						},
+					},
+				}
+				return dcCopy
+			},
+			Validate: func(t *testing.T, d *v1.DeploymentConfig) {
+				t.Log(d.Spec.Template.Spec.Volumes)
+				if len(d.Spec.Template.Spec.Volumes) > 1 {
+					t.Fatal("expected only once volume but got ", len(d.Spec.Template.Spec.Volumes))
+				}
+			},
+		},
+		{
+			Name: "test upgrade and is upgraded",
+			DC: func() *v1.DeploymentConfig {
+				return testDC
+			},
+			Validate: func(t *testing.T, d *v1.DeploymentConfig) {
+				if !keycloak.DeploymentUpgraded(d) {
+					t.Fatal("expected the deployment to be recognised as upgraded")
+				}
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.Name, func(t *testing.T) {
+			tc.Validate(t, keycloak.UpgradeDeploymentConfig(tc.DC()))
+		})
+	}
+}

--- a/vendor/github.com/openshift/api/apps/v1/register.go
+++ b/vendor/github.com/openshift/api/apps/v1/register.go
@@ -5,6 +5,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"fmt"
 )
 
 const (
@@ -29,6 +30,7 @@ func Resource(resource string) schema.GroupResource {
 
 // Adds the list of known types to api.Scheme.
 func addLegacyKnownTypes(scheme *runtime.Scheme) error {
+	fmt.Println("adding legacy scale ")
 	types := []runtime.Object{
 		&DeploymentConfig{},
 		&DeploymentConfigList{},

--- a/vendor/github.com/openshift/client-go/apps/clientset/versioned/clientset.go
+++ b/vendor/github.com/openshift/client-go/apps/clientset/versioned/clientset.go
@@ -1,0 +1,82 @@
+package versioned
+
+import (
+	glog "github.com/golang/glog"
+	appsv1 "github.com/openshift/client-go/apps/clientset/versioned/typed/apps/v1"
+	discovery "k8s.io/client-go/discovery"
+	rest "k8s.io/client-go/rest"
+	flowcontrol "k8s.io/client-go/util/flowcontrol"
+)
+
+type Interface interface {
+	Discovery() discovery.DiscoveryInterface
+	AppsV1() appsv1.AppsV1Interface
+	// Deprecated: please explicitly pick a version if possible.
+	Apps() appsv1.AppsV1Interface
+}
+
+// Clientset contains the clients for groups. Each group has exactly one
+// version included in a Clientset.
+type Clientset struct {
+	*discovery.DiscoveryClient
+	appsV1 *appsv1.AppsV1Client
+}
+
+// AppsV1 retrieves the AppsV1Client
+func (c *Clientset) AppsV1() appsv1.AppsV1Interface {
+	return c.appsV1
+}
+
+// Deprecated: Apps retrieves the default version of AppsClient.
+// Please explicitly pick a version.
+func (c *Clientset) Apps() appsv1.AppsV1Interface {
+	return c.appsV1
+}
+
+// Discovery retrieves the DiscoveryClient
+func (c *Clientset) Discovery() discovery.DiscoveryInterface {
+	if c == nil {
+		return nil
+	}
+	return c.DiscoveryClient
+}
+
+// NewForConfig creates a new Clientset for the given config.
+func NewForConfig(c *rest.Config) (*Clientset, error) {
+	configShallowCopy := *c
+	if configShallowCopy.RateLimiter == nil && configShallowCopy.QPS > 0 {
+		configShallowCopy.RateLimiter = flowcontrol.NewTokenBucketRateLimiter(configShallowCopy.QPS, configShallowCopy.Burst)
+	}
+	var cs Clientset
+	var err error
+	cs.appsV1, err = appsv1.NewForConfig(&configShallowCopy)
+	if err != nil {
+		return nil, err
+	}
+
+	cs.DiscoveryClient, err = discovery.NewDiscoveryClientForConfig(&configShallowCopy)
+	if err != nil {
+		glog.Errorf("failed to create the DiscoveryClient: %v", err)
+		return nil, err
+	}
+	return &cs, nil
+}
+
+// NewForConfigOrDie creates a new Clientset for the given config and
+// panics if there is an error in the config.
+func NewForConfigOrDie(c *rest.Config) *Clientset {
+	var cs Clientset
+	cs.appsV1 = appsv1.NewForConfigOrDie(c)
+
+	cs.DiscoveryClient = discovery.NewDiscoveryClientForConfigOrDie(c)
+	return &cs
+}
+
+// New creates a new Clientset for the given RESTClient.
+func New(c rest.Interface) *Clientset {
+	var cs Clientset
+	cs.appsV1 = appsv1.New(c)
+
+	cs.DiscoveryClient = discovery.NewDiscoveryClient(c)
+	return &cs
+}

--- a/vendor/github.com/openshift/client-go/apps/clientset/versioned/doc.go
+++ b/vendor/github.com/openshift/client-go/apps/clientset/versioned/doc.go
@@ -1,0 +1,2 @@
+// This package has the automatically generated clientset.
+package versioned

--- a/vendor/github.com/openshift/client-go/apps/clientset/versioned/fake/clientset_generated.go
+++ b/vendor/github.com/openshift/client-go/apps/clientset/versioned/fake/clientset_generated.go
@@ -1,0 +1,55 @@
+package fake
+
+import (
+	clientset "github.com/openshift/client-go/apps/clientset/versioned"
+	appsv1 "github.com/openshift/client-go/apps/clientset/versioned/typed/apps/v1"
+	fakeappsv1 "github.com/openshift/client-go/apps/clientset/versioned/typed/apps/v1/fake"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/watch"
+	"k8s.io/client-go/discovery"
+	fakediscovery "k8s.io/client-go/discovery/fake"
+	"k8s.io/client-go/testing"
+)
+
+// NewSimpleClientset returns a clientset that will respond with the provided objects.
+// It's backed by a very simple object tracker that processes creates, updates and deletions as-is,
+// without applying any validations and/or defaults. It shouldn't be considered a replacement
+// for a real clientset and is mostly useful in simple unit tests.
+func NewSimpleClientset(objects ...runtime.Object) *Clientset {
+	o := testing.NewObjectTracker(scheme, codecs.UniversalDecoder())
+	for _, obj := range objects {
+		if err := o.Add(obj); err != nil {
+			panic(err)
+		}
+	}
+
+	fakePtr := testing.Fake{}
+	fakePtr.AddReactor("*", "*", testing.ObjectReaction(o))
+	fakePtr.AddWatchReactor("*", testing.DefaultWatchReactor(watch.NewFake(), nil))
+
+	return &Clientset{fakePtr, &fakediscovery.FakeDiscovery{Fake: &fakePtr}}
+}
+
+// Clientset implements clientset.Interface. Meant to be embedded into a
+// struct to get a default implementation. This makes faking out just the method
+// you want to test easier.
+type Clientset struct {
+	testing.Fake
+	discovery *fakediscovery.FakeDiscovery
+}
+
+func (c *Clientset) Discovery() discovery.DiscoveryInterface {
+	return c.discovery
+}
+
+var _ clientset.Interface = &Clientset{}
+
+// AppsV1 retrieves the AppsV1Client
+func (c *Clientset) AppsV1() appsv1.AppsV1Interface {
+	return &fakeappsv1.FakeAppsV1{Fake: &c.Fake}
+}
+
+// Apps retrieves the AppsV1Client
+func (c *Clientset) Apps() appsv1.AppsV1Interface {
+	return &fakeappsv1.FakeAppsV1{Fake: &c.Fake}
+}

--- a/vendor/github.com/openshift/client-go/apps/clientset/versioned/fake/doc.go
+++ b/vendor/github.com/openshift/client-go/apps/clientset/versioned/fake/doc.go
@@ -1,0 +1,2 @@
+// This package has the automatically generated fake clientset.
+package fake

--- a/vendor/github.com/openshift/client-go/apps/clientset/versioned/fake/register.go
+++ b/vendor/github.com/openshift/client-go/apps/clientset/versioned/fake/register.go
@@ -1,0 +1,37 @@
+package fake
+
+import (
+	appsv1 "github.com/openshift/api/apps/v1"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	runtime "k8s.io/apimachinery/pkg/runtime"
+	schema "k8s.io/apimachinery/pkg/runtime/schema"
+	serializer "k8s.io/apimachinery/pkg/runtime/serializer"
+)
+
+var scheme = runtime.NewScheme()
+var codecs = serializer.NewCodecFactory(scheme)
+var parameterCodec = runtime.NewParameterCodec(scheme)
+
+func init() {
+	v1.AddToGroupVersion(scheme, schema.GroupVersion{Version: "v1"})
+	AddToScheme(scheme)
+}
+
+// AddToScheme adds all types of this clientset into the given scheme. This allows composition
+// of clientsets, like in:
+//
+//   import (
+//     "k8s.io/client-go/kubernetes"
+//     clientsetscheme "k8s.io/client-go/kuberentes/scheme"
+//     aggregatorclientsetscheme "k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset/scheme"
+//   )
+//
+//   kclientset, _ := kubernetes.NewForConfig(c)
+//   aggregatorclientsetscheme.AddToScheme(clientsetscheme.Scheme)
+//
+// After this, RawExtensions in Kubernetes types will serialize kube-aggregator types
+// correctly.
+func AddToScheme(scheme *runtime.Scheme) {
+	appsv1.AddToScheme(scheme)
+
+}

--- a/vendor/github.com/openshift/client-go/apps/clientset/versioned/typed/apps/v1/fake/doc.go
+++ b/vendor/github.com/openshift/client-go/apps/clientset/versioned/typed/apps/v1/fake/doc.go
@@ -1,0 +1,2 @@
+// Package fake has the automatically generated clients.
+package fake

--- a/vendor/github.com/openshift/client-go/apps/clientset/versioned/typed/apps/v1/fake/fake_apps_client.go
+++ b/vendor/github.com/openshift/client-go/apps/clientset/versioned/typed/apps/v1/fake/fake_apps_client.go
@@ -1,0 +1,22 @@
+package fake
+
+import (
+	v1 "github.com/openshift/client-go/apps/clientset/versioned/typed/apps/v1"
+	rest "k8s.io/client-go/rest"
+	testing "k8s.io/client-go/testing"
+)
+
+type FakeAppsV1 struct {
+	*testing.Fake
+}
+
+func (c *FakeAppsV1) DeploymentConfigs(namespace string) v1.DeploymentConfigInterface {
+	return &FakeDeploymentConfigs{c, namespace}
+}
+
+// RESTClient returns a RESTClient that is used to communicate
+// with API server by this client implementation.
+func (c *FakeAppsV1) RESTClient() rest.Interface {
+	var ret *rest.RESTClient
+	return ret
+}

--- a/vendor/github.com/openshift/client-go/apps/clientset/versioned/typed/apps/v1/fake/fake_deploymentconfig.go
+++ b/vendor/github.com/openshift/client-go/apps/clientset/versioned/typed/apps/v1/fake/fake_deploymentconfig.go
@@ -1,0 +1,167 @@
+package fake
+
+import (
+	apps_v1 "github.com/openshift/api/apps/v1"
+	v1beta1 "k8s.io/api/extensions/v1beta1"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	labels "k8s.io/apimachinery/pkg/labels"
+	schema "k8s.io/apimachinery/pkg/runtime/schema"
+	types "k8s.io/apimachinery/pkg/types"
+	watch "k8s.io/apimachinery/pkg/watch"
+	testing "k8s.io/client-go/testing"
+)
+
+// FakeDeploymentConfigs implements DeploymentConfigInterface
+type FakeDeploymentConfigs struct {
+	Fake *FakeAppsV1
+	ns   string
+}
+
+var deploymentconfigsResource = schema.GroupVersionResource{Group: "apps.openshift.io", Version: "v1", Resource: "deploymentconfigs"}
+
+var deploymentconfigsKind = schema.GroupVersionKind{Group: "apps.openshift.io", Version: "v1", Kind: "DeploymentConfig"}
+
+// Get takes name of the deploymentConfig, and returns the corresponding deploymentConfig object, and an error if there is any.
+func (c *FakeDeploymentConfigs) Get(name string, options v1.GetOptions) (result *apps_v1.DeploymentConfig, err error) {
+	obj, err := c.Fake.
+		Invokes(testing.NewGetAction(deploymentconfigsResource, c.ns, name), &apps_v1.DeploymentConfig{})
+
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*apps_v1.DeploymentConfig), err
+}
+
+// List takes label and field selectors, and returns the list of DeploymentConfigs that match those selectors.
+func (c *FakeDeploymentConfigs) List(opts v1.ListOptions) (result *apps_v1.DeploymentConfigList, err error) {
+	obj, err := c.Fake.
+		Invokes(testing.NewListAction(deploymentconfigsResource, deploymentconfigsKind, c.ns, opts), &apps_v1.DeploymentConfigList{})
+
+	if obj == nil {
+		return nil, err
+	}
+
+	label, _, _ := testing.ExtractFromListOptions(opts)
+	if label == nil {
+		label = labels.Everything()
+	}
+	list := &apps_v1.DeploymentConfigList{}
+	for _, item := range obj.(*apps_v1.DeploymentConfigList).Items {
+		if label.Matches(labels.Set(item.Labels)) {
+			list.Items = append(list.Items, item)
+		}
+	}
+	return list, err
+}
+
+// Watch returns a watch.Interface that watches the requested deploymentConfigs.
+func (c *FakeDeploymentConfigs) Watch(opts v1.ListOptions) (watch.Interface, error) {
+	return c.Fake.
+		InvokesWatch(testing.NewWatchAction(deploymentconfigsResource, c.ns, opts))
+
+}
+
+// Create takes the representation of a deploymentConfig and creates it.  Returns the server's representation of the deploymentConfig, and an error, if there is any.
+func (c *FakeDeploymentConfigs) Create(deploymentConfig *apps_v1.DeploymentConfig) (result *apps_v1.DeploymentConfig, err error) {
+	obj, err := c.Fake.
+		Invokes(testing.NewCreateAction(deploymentconfigsResource, c.ns, deploymentConfig), &apps_v1.DeploymentConfig{})
+
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*apps_v1.DeploymentConfig), err
+}
+
+// Update takes the representation of a deploymentConfig and updates it. Returns the server's representation of the deploymentConfig, and an error, if there is any.
+func (c *FakeDeploymentConfigs) Update(deploymentConfig *apps_v1.DeploymentConfig) (result *apps_v1.DeploymentConfig, err error) {
+	obj, err := c.Fake.
+		Invokes(testing.NewUpdateAction(deploymentconfigsResource, c.ns, deploymentConfig), &apps_v1.DeploymentConfig{})
+
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*apps_v1.DeploymentConfig), err
+}
+
+// UpdateStatus was generated because the type contains a Status member.
+// Add a +genclient:noStatus comment above the type to avoid generating UpdateStatus().
+func (c *FakeDeploymentConfigs) UpdateStatus(deploymentConfig *apps_v1.DeploymentConfig) (*apps_v1.DeploymentConfig, error) {
+	obj, err := c.Fake.
+		Invokes(testing.NewUpdateSubresourceAction(deploymentconfigsResource, "status", c.ns, deploymentConfig), &apps_v1.DeploymentConfig{})
+
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*apps_v1.DeploymentConfig), err
+}
+
+// Delete takes name of the deploymentConfig and deletes it. Returns an error if one occurs.
+func (c *FakeDeploymentConfigs) Delete(name string, options *v1.DeleteOptions) error {
+	_, err := c.Fake.
+		Invokes(testing.NewDeleteAction(deploymentconfigsResource, c.ns, name), &apps_v1.DeploymentConfig{})
+
+	return err
+}
+
+// DeleteCollection deletes a collection of objects.
+func (c *FakeDeploymentConfigs) DeleteCollection(options *v1.DeleteOptions, listOptions v1.ListOptions) error {
+	action := testing.NewDeleteCollectionAction(deploymentconfigsResource, c.ns, listOptions)
+
+	_, err := c.Fake.Invokes(action, &apps_v1.DeploymentConfigList{})
+	return err
+}
+
+// Patch applies the patch and returns the patched deploymentConfig.
+func (c *FakeDeploymentConfigs) Patch(name string, pt types.PatchType, data []byte, subresources ...string) (result *apps_v1.DeploymentConfig, err error) {
+	obj, err := c.Fake.
+		Invokes(testing.NewPatchSubresourceAction(deploymentconfigsResource, c.ns, name, data, subresources...), &apps_v1.DeploymentConfig{})
+
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*apps_v1.DeploymentConfig), err
+}
+
+// Instantiate takes the representation of a deploymentRequest and creates it.  Returns the server's representation of the deploymentConfig, and an error, if there is any.
+func (c *FakeDeploymentConfigs) Instantiate(deploymentConfigName string, deploymentRequest *apps_v1.DeploymentRequest) (result *apps_v1.DeploymentConfig, err error) {
+	obj, err := c.Fake.
+		Invokes(testing.NewCreateSubresourceAction(deploymentconfigsResource, deploymentConfigName, "instantiate", c.ns, deploymentRequest), &apps_v1.DeploymentConfig{})
+
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*apps_v1.DeploymentConfig), err
+}
+
+// Rollback takes the representation of a deploymentConfigRollback and creates it.  Returns the server's representation of the deploymentConfig, and an error, if there is any.
+func (c *FakeDeploymentConfigs) Rollback(deploymentConfigName string, deploymentConfigRollback *apps_v1.DeploymentConfigRollback) (result *apps_v1.DeploymentConfig, err error) {
+	obj, err := c.Fake.
+		Invokes(testing.NewCreateSubresourceAction(deploymentconfigsResource, deploymentConfigName, "rollback", c.ns, deploymentConfigRollback), &apps_v1.DeploymentConfig{})
+
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*apps_v1.DeploymentConfig), err
+}
+
+// GetScale takes name of the deploymentConfig, and returns the corresponding scale object, and an error if there is any.
+func (c *FakeDeploymentConfigs) GetScale(deploymentConfigName string, options v1.GetOptions) (result *v1beta1.Scale, err error) {
+	obj, err := c.Fake.
+		Invokes(testing.NewGetSubresourceAction(deploymentconfigsResource, c.ns, "scale", deploymentConfigName), &v1beta1.Scale{})
+
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*v1beta1.Scale), err
+}
+
+// UpdateScale takes the representation of a scale and updates it. Returns the server's representation of the scale, and an error, if there is any.
+func (c *FakeDeploymentConfigs) UpdateScale(deploymentConfigName string, scale *v1beta1.Scale) (result *v1beta1.Scale, err error) {
+	obj, err := c.Fake.
+		Invokes(testing.NewUpdateSubresourceAction(deploymentconfigsResource, "scale", c.ns, scale), &v1beta1.Scale{})
+
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*v1beta1.Scale), err
+}

--- a/vendor/k8s.io/client-go/rest/request.go
+++ b/vendor/k8s.io/client-go/rest/request.go
@@ -756,6 +756,7 @@ func (r *Request) Do() Result {
 	r.tryThrottle()
 
 	var result Result
+	//fmt.Println("calling url ", r.URL().String())
 	err := r.request(func(req *http.Request, resp *http.Response) {
 		result = r.transformResponse(resp, req)
 	})


### PR DESCRIPTION
## Motivation
Upgrade from 7.2 sso to 7.3


## Verification Steps

- provision a 1.4.1 cluster and login with the customer-admin
- Import the sso 7.3 image stream ``` oc -n openshift import-image redhat-sso73-openshift:1.0 ``` done by installer for upgrade
- Login with the admin user and update the existing keycloak operator to this PR image build
- Ensure the SSO instance is scaled down redeployed and scaled up
- Ensure you can still login to the openshift cluster and the various components


## Checklist:

- [x] Code has been tested locally by PR requester
- [x] Changes have been successfully verified by another team member

