### PR TITLE
fix bad logic in wait for pods stage

### DIFF
--- a/deploy/examples/keycloak.json
+++ b/deploy/examples/keycloak.json
@@ -6,6 +6,7 @@
   },
   "spec": {
     "adminCredentials": "",
-    "plugins": ["keycloak-metrics-spi"]
+    "plugins": ["keycloak-metrics-spi"],
+    "provision": true
   }
 }

--- a/pkg/keycloak/phaseHandler.go
+++ b/pkg/keycloak/phaseHandler.go
@@ -152,10 +152,17 @@ func (ph *phaseHandler) WaitforPods(sso *v1alpha1.Keycloak) (*v1alpha1.Keycloak,
 	}
 	//wait for all the SSO pods to be ready
 	for _, pod := range podList.Items {
+		gotReady := false
 		for _, condition := range pod.Status.Conditions {
-			if condition.Type == "Ready" && condition.Status != "True" {
-				return kc, nil
+			if condition.Type == "Ready" {
+				gotReady = true
+				if condition.Status != "True" {
+					return kc, nil
+				}
 			}
+		}
+		if !gotReady {
+			return kc, nil
 		}
 	}
 	//get the route to keycloak admin


### PR DESCRIPTION
it seems the check for ready pods in keycloak-operator was buggy causing unreliable deploys on Openshift 4.

## Verification
- Deploy to Openshift 4
- Deploy the keycloak.json sample CR
- See keycloak come up normally

This does occasionally work anyway, so might be worth repeating the verification a few times to be certain.