### PR TITLE
fix upgrade logic

### DIFF
--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -14,7 +14,7 @@ spec:
     spec:
       containers:
         - name: keycloak-operator
-          image: quay.io/integreatly/keycloak-operator:v1.7.4
+          image: quay.io/integreatly/keycloak-operator:v1.7.5
           ports:
           - containerPort: 60000
             name: metrics

--- a/pkg/keycloak/keycloak.go
+++ b/pkg/keycloak/keycloak.go
@@ -127,6 +127,8 @@ func (h *Reconciler) Handle(ctx context.Context, object interface{}, deleted boo
 	}
 	if kcState == nil {
 		return nil
+	} else if kcState.Status.Phase == v1alpha1.PhaseUpgrading {
+		return h.sdkCrud.Update(kcState)
 	}
 
 	switch kcState.Status.Phase {

--- a/pkg/keycloak/phaseHandler.go
+++ b/pkg/keycloak/phaseHandler.go
@@ -106,16 +106,16 @@ func (ph *phaseHandler) Accepted(sso *v1alpha1.Keycloak) (*v1alpha1.Keycloak, er
 func (ph *phaseHandler) Upgrade(sso *v1alpha1.Keycloak) (*v1alpha1.Keycloak, error) {
 	cpSSO := sso.DeepCopy()
 	if !CanUpgrade(cpSSO.Status.Version) || (cpSSO.Status.Phase != v1alpha1.PhaseUpgrading && cpSSO.Status.Phase != v1alpha1.PhaseReconcile) {
-		logrus.Debug("not upgrading from version ", cpSSO.Status.Version, " in phase ", cpSSO.Status.Phase)
 		cpSSO.Status.Message = "not upgrading. Version is either current or there is no upgrade path."
 		return cpSSO, nil
 	}
+	logrus.Info("Can upgrade")
 	dc, err := ph.ocDCClient.DeploymentConfigs(cpSSO.Namespace).Get(SSO_APPLICATION_NAME, v12.GetOptions{})
 	if err != nil {
 		return cpSSO, errors.Wrap(err, "failed to get current deploymentconfig for sso")
 	}
 	if cpSSO.Status.Phase == v1alpha1.PhaseReconcile {
-		logrus.Debug("marking for upgrade ", cpSSO.Status.Version, cpSSO.Status.Phase)
+		logrus.Infof("marking for upgrade %s %s", cpSSO.Status.Version, cpSSO.Status.Phase)
 		cpSSO.Status.Phase = v1alpha1.PhaseUpgrading
 		cpSSO.Status.Replicas = dc.Spec.Replicas
 		return cpSSO, nil

--- a/pkg/keycloak/upgrade.go
+++ b/pkg/keycloak/upgrade.go
@@ -85,6 +85,12 @@ func ServiceUpgraded(service *cv1.Service) bool {
 }
 
 func UpgradeDeploymentConfig(dc *v1.DeploymentConfig) *v1.DeploymentConfig {
+	for i, _ := range dc.Spec.Template.Spec.InitContainers {
+		if dc.Spec.Template.Spec.InitContainers[i].Name == "sso-plugins-init" {
+			logrus.Infof("updated init container image")
+			dc.Spec.Template.Spec.InitContainers[i].Image = "quay.io/integreatly/sso_plugins_init:0.0.3"
+		}
+	}
 	for _, t := range dc.Spec.Triggers {
 		if t.Type == v1.DeploymentTriggerOnImageChange {
 			t.ImageChangeParams.From.Name = SSO_IMAGE_STREAM


### PR DESCRIPTION
## Motivation
INTLY-2777

## Verification Steps
in openshift 3 cluster:
- oc tag --source=docker registry.redhat.io/redhat-sso-7/sso72-openshift:1.4 openshift/redhat-sso72-openshift:1.4
- oc -n openshift import-image redhat-sso72-openshift:1.4
- oc tag --source=docker registry.redhat.io/redhat-sso-7/sso73-openshift:1.0 openshift/redhat-sso73-openshift:1.0
- oc -n openshift import-image redhat-sso73-openshift:1.0
- create a test namespace
- `make cluster/prepare NAMESPACE=<test namespace>`
- edit deploy/operator.yaml and set image tag to: `v1.3.6`
- `oc create -f deploy/operator.yaml`
- `make cluster/create/examples NAMESPACE=<test namespace>`
- Wait for RHSSO 7.2 to come up
- edit operator deployment and set the image to: `quay.io/philbrookes/keycloak-operator:v1.7.5`
- see the upgrade is succesful