### PR TITLE
add linkOnly property to the identity provider in the kc realm crd

### DIFF
--- a/deploy/crds/KeycloakRealm_crd.yaml
+++ b/deploy/crds/KeycloakRealm_crd.yaml
@@ -53,6 +53,8 @@ spec:
                     type: string
                   postBrokerLoginFlowAlias:
                     type: string
+                  linkOnly:
+                    type: boolean              
                   config:
                     type: object
             users:


### PR DESCRIPTION
## Motivation
New property `linkOnly` was added into the types (https://github.com/integr8ly/keycloak-operator/pull/90). This also needs to be added to the Keycloak Realm CRD.

## What
Add `linkOnly` under Identity Provider property in the Keycloak Realm CRD.