### PR TITLE
Intly 2352

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,12 +4,12 @@ CONSUMER_NAMESPACES=${NAMESPACE}
 PROJECT=keycloak-operator
 REG=quay.io
 SHELL=/bin/bash
-TAG=v1.8.2
+TAG=v1.8.3
 PKG=github.com/integr8ly/keycloak-operator
 TEST_DIRS?=$(shell sh -c "find $(TOP_SRC_DIRS) -name \\*_test.go -exec dirname {} \\; | sort | uniq")
 TEST_POD_NAME=keycloak-operator-test
 COMPILE_TARGET=./tmp/_output/bin/$(PROJECT)
-OPERATOR_SDK_BINARY=./operator-sdk-v0.0.7-x86_64-apple-darwin
+OPERATOR_SDK_BINARY=operator-sdk
 
 .PHONY: setup/dep
 setup/dep:

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ PKG=github.com/integr8ly/keycloak-operator
 TEST_DIRS?=$(shell sh -c "find $(TOP_SRC_DIRS) -name \\*_test.go -exec dirname {} \\; | sort | uniq")
 TEST_POD_NAME=keycloak-operator-test
 COMPILE_TARGET=./tmp/_output/bin/$(PROJECT)
-OPERATOR_SDK_BINARY=operator-sdk
+OPERATOR_SDK_BINARY=./operator-sdk-v0.0.7-x86_64-apple-darwin
 
 .PHONY: setup/dep
 setup/dep:

--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -14,7 +14,7 @@ spec:
     spec:
       containers:
         - name: keycloak-operator
-          image: quay.io/integreatly/keycloak-operator:v1.8.2
+          image: quay.io/integreatly/keycloak-operator:v1.8.3
           ports:
           - containerPort: 60000
             name: metrics

--- a/deploy/template/prometheus-rule.yaml
+++ b/deploy/template/prometheus-rule.yaml
@@ -83,7 +83,7 @@ spec:
         - alert: KeycloakInstanceNotAvailable
           annotations:
             message: >-
-              Keycloak instance in namespace {{ '{{' }} $labels.namespace {{ '}}' }} has not
+              Keycloak instance in namespace {{ $labels.namespace }} has not
               been available for the last 5 minutes.
           expr: >
             (1 - absent(kube_pod_status_ready{namespace="sso", condition="true"}
@@ -96,7 +96,7 @@ spec:
         - alert: KeycloakAPIRequestDuration90PercThresholdExceeded
           annotations:
             message: >-
-              Less than 90% of the RH SSO API endpoints in namespace {{ '{{' }} $labels.namespace {{ '}}' }} are taking longer than 1s for the last 5 minutes.
+              Less than 90% of the RH SSO API endpoints in namespace {{ $labels.namespace }} are taking longer than 1s for the last 5 minutes.
           expr: >
             (sum(rate(keycloak_request_duration_bucket{le="1000.0"}[5m])) by (job) 
             /
@@ -107,7 +107,7 @@ spec:
         - alert: KeycloakAPIRequestDuration99PercThresholdExceeded
           annotations:
             message: >-
-              Less than 99.5% of the RH SSO API endpoints in namespace {{ '{{' }} $labels.namespace {{ '}}' }} are taking longer than 10s for the last 5 minutes.
+              Less than 99.5% of the RH SSO API endpoints in namespace {{ $labels.namespace }} are taking longer than 10s for the last 5 minutes.
           expr: >
             (sum(rate(keycloak_request_duration_bucket{le="10000.0"}[5m])) by (job) 
             /
@@ -118,7 +118,7 @@ spec:
         - alert: KeycloakDatabaseNotAvailable
           annotations:
             message: >-
-              RH SSO database in namespace {{ '{{' }} $labels.namespace {{ '}}' }} is not
+              RH SSO database in namespace {{ $labels.namespace }} is not
               available for the last 5 minutes.
           expr: >
             (1 - absent(kube_pod_status_ready{namespace="sso", condition="true"}

--- a/deploy/template/prometheus-rule.yaml
+++ b/deploy/template/prometheus-rule.yaml
@@ -80,3 +80,51 @@ spec:
           for: 5m
           labels:
             severity: warning
+        - alert: KeycloakInstanceNotAvailable
+          annotations:
+            message: >-
+              Keycloak instance in namespace {{ '{{' }} $labels.namespace {{ '}}' }} has not
+              been available for the last 5 minutes.
+          expr: >
+            (1 - absent(kube_pod_status_ready{namespace="sso", condition="true"}
+            * on (pod) group_left (label_deploymentConfig)
+            kube_pod_labels{label_deploymentConfig="sso"})) == 0 or
+            probe_success{service="rhsso-ui"} == 0 
+          for: 5m
+          labels:
+            severity: critical
+        - alert: KeycloakAPIRequestDuration90PercThresholdExceeded
+          annotations:
+            message: >-
+              Less than 90% of the RH SSO API endpoints in namespace {{ '{{' }} $labels.namespace {{ '}}' }} are taking longer than 1s for the last 5 minutes.
+          expr: >
+            (sum(rate(keycloak_request_duration_bucket{le="1000.0"}[5m])) by (job) 
+            /
+            sum(rate(keycloak_request_duration_count[5m])) by (job)) < 0.90
+          for: 5m
+          labels:
+            severity: critical
+        - alert: KeycloakAPIRequestDuration99PercThresholdExceeded
+          annotations:
+            message: >-
+              Less than 99.5% of the RH SSO API endpoints in namespace {{ '{{' }} $labels.namespace {{ '}}' }} are taking longer than 10s for the last 5 minutes.
+          expr: >
+            (sum(rate(keycloak_request_duration_bucket{le="10000.0"}[5m])) by (job) 
+            /
+            sum(rate(keycloak_request_duration_count[5m])) by (job)) < 0.995
+          for: 5m
+          labels:
+            severity: critical
+        - alert: KeycloakDatabaseNotAvailable
+          annotations:
+            message: >-
+              RH SSO database in namespace {{ '{{' }} $labels.namespace {{ '}}' }} is not
+              available for the last 5 minutes.
+          expr: >
+            (1 - absent(kube_pod_status_ready{namespace="sso", condition="true"}
+            * on (pod) group_left (label_deploymentConfig)
+            kube_pod_labels{label_deploymentConfig="sso-postgresql"})) == 0 
+          for: 5m
+          labels:
+            severity: critical
+

--- a/deploy/test-pod.yaml
+++ b/deploy/test-pod.yaml
@@ -6,7 +6,7 @@ spec:
   restartPolicy: Never
   containers:
   - name: keycloak-operator-test
-    image: quay.io/integreatly/keycloak-operator:v1.8.2
+    image: quay.io/integreatly/keycloak-operator:v1.8.3
     imagePullPolicy: Always
     command: ["/go-test.sh"]
     env:

--- a/version/version.go
+++ b/version/version.go
@@ -1,5 +1,5 @@
 package version
 
 var (
-	Version = "1.8.2"
+	Version = "1.8.3"
 )


### PR DESCRIPTION
## Motivation
https://issues.jboss.org/browse/INTLY-2352

## What
Adding new alerts for the Keycloak instance, database and request duration are below a certain threshold. 90% of requests are returning under 1s, 99.5% of requests are returning under 10s.

## Why
To satisfy the mandatory SLIs for RHSSO in the SLI document for RHMI

## Checklist:

- [ ] Code has been tested locally by PR requester
- [ ] Changes have been successfully verified by another team member

## Progress

- [x] Finished task
- [ ] TODO
