### PR TITLE
use postgres version 9.6

### DIFF
--- a/pkg/keycloak/keycloak.go
+++ b/pkg/keycloak/keycloak.go
@@ -29,6 +29,7 @@ const (
 	SSO_TEMPLATE_PATH_ENV_VAR = "TEMPLATE_DIR"
 	SSO_VERSION               = "v7.3.2.GA"
 	SSO_IMAGE_STREAM          = "redhat-sso73-openshift:1.0"
+	SSO_POSTGRES_VERSION      = "9.6"
 )
 
 //go:generate moq -out sdkCruder_moq.go . SdkCruder


### PR DESCRIPTION
## Motivation
The default postgres image tag (9.5) used in the sso template is not available in an OpenShift 4.2 cluster.

## What
This change adds a parameter injector function which is used to specify the value 9.6 for the POSTGRESQL_IMAGE_STREAM_TAG parameter in the template.

## Verification Steps
1. Run the operator locally or point the keycloak operator to `quay.io/jameelb/keycloak-operator:v1.9.4` or point your operator source to the app registry `jameelb`
2. Verify that the postgresql image points to the tag `9.6`
3. Verify that Keycloak was deployed successfully

## Checklist:

- [x] Code has been tested locally by PR requester
- [ ] Changes have been successfully verified by another team member
